### PR TITLE
Revert "Update bignum.h"

### DIFF
--- a/src/bignum.h
+++ b/src/bignum.h
@@ -626,7 +626,7 @@ public:
     bool isPrime(const int checks=BN_prime_checks) const {
         CAutoBN_CTX pctx;
 
-        int ret = BN_is_prime_ex(bn, pctx, NULL);
+        int ret = BN_check_prime(bn, pctx, NULL);
 
         if(ret < 0){
             throw bignum_error("CBigNum::isPrime :BN_is_prime");

--- a/src/key.cpp
+++ b/src/key.cpp
@@ -18,6 +18,10 @@
 
 #include "key.h"
 
+#if OPENSSL_VERSION_NUMBER < 0x30000000L
+#error "OpenSSL 1 has reached EOL and is not supported anymore, please upgrade to OpenSSL 3"
+#endif
+
 // anonymous namespace with local implementation code (OpenSSL interaction)
 namespace {
 


### PR DESCRIPTION
This reverts commit "32a6fde5e3ba2f2c1053147a30b40de7d06fae78".
Just make it explicit that OpenSSL 1 is not supported anymore.